### PR TITLE
Added missing headers in adopt_policy.hpp

### DIFF
--- a/luabind/adopt_policy.hpp
+++ b/luabind/adopt_policy.hpp
@@ -33,6 +33,9 @@
 #include <luabind/detail/policy.hpp>
 #include <luabind/back_reference_fwd.hpp>
 
+#include <luabind/detail/conversion_policies/pointer_converter.hpp>
+#include <luabind/detail/typetraits.hpp>
+
 namespace luabind {
 	namespace detail {
 


### PR DESCRIPTION
Fixes a compilation error when compiling LunaLua with Clang